### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -14,9 +14,9 @@ BigIOT	KEYWORD1
 
 login	KEYWORD2
 waiting	KEYWORD2
-update_data_stream KEYWORD2
-update_location_data KEYWORD2
-send_alarm_message KEYWORD2
+update_data_stream	KEYWORD2
+update_location_data	KEYWORD2
+send_alarm_message	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords